### PR TITLE
Rename variable in word cloud helper

### DIFF
--- a/tweet_sentiment.ipynb
+++ b/tweet_sentiment.ipynb
@@ -2636,10 +2636,10 @@
       "outputs": [],
       "source": [
         "def word_cloud(text):\n",
-        "    allw = ' '.join([sent for sent in text])\n",
+        "    all_words = ' '.join([sent for sent in text])\n",
         "    wcloud = WordCloud(width= 800, height= 500,\n",
         "                              max_font_size = 110,\n",
-        "                              collocations = False).generate(allw)\n",
+        "                              collocations = False).generate(all_words)\n",
         "    plt.figure(figsize=(24,12))\n",
         "    plt.imshow(wcloud, interpolation='bilinear')\n",
         "    plt.axis(\"off\")\n",


### PR DESCRIPTION
## Summary
- rename the `allw` variable in the tweet sentiment notebook's `word_cloud` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c512d712483298a0a95dda3e150e9