### PR TITLE
Fix stoplist usage in movie-nlp notebook

### DIFF
--- a/movie-nlp.ipynb
+++ b/movie-nlp.ipynb
@@ -569,7 +569,7 @@
         "\n",
         "%time dictionary = corpora.Dictionary(movie_plot)\n",
         "\n",
-        "stoplist = set('hello and if this can would should could tell ask stop come go')\n",
+        "stoplist = set('hello and if this can would should could tell ask stop come go'.split())  # create a set of stop words, not individual characters\n",
         "stop_ids = [dictionary.token2id[stopword] for stopword in stoplist if stopword in dictionary.token2id]\n",
         "dictionary.filter_tokens(stop_ids)"
       ],


### PR DESCRIPTION
## Summary
- correct `stoplist` creation in movie NLP notebook
- clarify comment that the stoplist now contains entire words

## Testing
- `pytest -q` *(no tests found)*
- ❌ `pip install gensim` *(failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687c53ca1a74832985171052c9b4f46b