### PR TITLE
Add ML framework examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # making-sense
 Making sense of frameworks and libs
+
+## Example Code
+
+The `examples` directory contains standalone scripts showing how to use
+common machine learning frameworks:
+
+- `simple_nn.py` &ndash; a neural network from scratch using NumPy.
+- `pytorch_example.py` &ndash; a basic model built with PyTorch.
+- `sklearn_example.py` &ndash; logistic regression using scikit-learn.
+- `tensorflow_example.py` &ndash; a Keras model in TensorFlow.
+- `huggingface_example.py` &ndash; sentiment analysis with a pretrained
+  Hugging Face Transformer.
+
+Run any script with `python <script name>` to see it in action.

--- a/examples/huggingface_example.py
+++ b/examples/huggingface_example.py
@@ -1,0 +1,13 @@
+from transformers import pipeline
+
+
+def run_sentiment_analysis(text: str = "I love using Transformers models!"):
+    """Run sentiment analysis using a pretrained Hugging Face model."""
+    classifier = pipeline("sentiment-analysis",
+                         model="distilbert-base-uncased-finetuned-sst-2-english")
+    result = classifier(text)[0]
+    print(f"label: {result['label']}, score: {result['score']:.2f}")
+
+
+if __name__ == "__main__":
+    run_sentiment_analysis()

--- a/examples/pytorch_example.py
+++ b/examples/pytorch_example.py
@@ -1,0 +1,36 @@
+import torch
+from torch import nn
+
+
+def train_pytorch_model(num_samples: int = 1000, input_dim: int = 10, hidden_dim: int = 32,
+                        num_classes: int = 3, epochs: int = 20):
+    """Train a simple feedforward network using PyTorch."""
+    X = torch.randn(num_samples, input_dim)
+    y = torch.randint(0, num_classes, (num_samples,))
+
+    model = nn.Sequential(
+        nn.Linear(input_dim, hidden_dim),
+        nn.ReLU(),
+        nn.Linear(hidden_dim, num_classes)
+    )
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters())
+
+    for epoch in range(epochs):
+        logits = model(X)
+        loss = criterion(logits, y)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if epoch % 5 == 0:
+            print(f"Epoch {epoch}, loss: {loss.item():.4f}")
+
+    with torch.no_grad():
+        preds = model(X).argmax(dim=1)
+        accuracy = (preds == y).float().mean().item()
+    print(f"Training accuracy: {accuracy:.2%}")
+
+
+if __name__ == "__main__":
+    train_pytorch_model()

--- a/examples/simple_nn.py
+++ b/examples/simple_nn.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+
+def relu(x):
+    return np.maximum(0, x)
+
+
+def softmax(x):
+    e_x = np.exp(x - np.max(x, axis=1, keepdims=True))
+    return e_x / e_x.sum(axis=1, keepdims=True)
+
+
+def train_simple_nn(num_samples: int = 1000, hidden_size: int = 16, num_classes: int = 3,
+                    epochs: int = 100, lr: float = 0.1):
+    """Train a toy neural network with one hidden layer using numpy."""
+    X = np.random.randn(num_samples, 10)
+    y = np.random.randint(0, num_classes, size=num_samples)
+
+    W1 = np.random.randn(10, hidden_size) * 0.01
+    b1 = np.zeros((1, hidden_size))
+    W2 = np.random.randn(hidden_size, num_classes) * 0.01
+    b2 = np.zeros((1, num_classes))
+
+    for epoch in range(epochs):
+        z1 = X.dot(W1) + b1
+        a1 = relu(z1)
+        logits = a1.dot(W2) + b2
+        probs = softmax(logits)
+
+        one_hot = np.eye(num_classes)[y]
+        loss = -np.mean(np.sum(one_hot * np.log(probs + 1e-8), axis=1))
+
+        if epoch % 10 == 0:
+            print(f"Epoch {epoch}, loss: {loss:.4f}")
+
+        grad_logits = probs - one_hot
+        grad_W2 = a1.T.dot(grad_logits) / num_samples
+        grad_b2 = grad_logits.mean(axis=0, keepdims=True)
+
+        grad_a1 = grad_logits.dot(W2.T)
+        grad_z1 = grad_a1 * (z1 > 0)
+        grad_W1 = X.T.dot(grad_z1) / num_samples
+        grad_b1 = grad_z1.mean(axis=0, keepdims=True)
+
+        W2 -= lr * grad_W2
+        b2 -= lr * grad_b2
+        W1 -= lr * grad_W1
+        b1 -= lr * grad_b1
+
+    preds = probs.argmax(axis=1)
+    accuracy = (preds == y).mean()
+    print(f"Training accuracy: {accuracy:.2%}")
+
+
+if __name__ == "__main__":
+    train_simple_nn()

--- a/examples/sklearn_example.py
+++ b/examples/sklearn_example.py
@@ -1,0 +1,25 @@
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.metrics import accuracy_score
+
+
+def train_sklearn_model():
+    """Train a logistic regression classifier on the iris dataset."""
+    iris = datasets.load_iris()
+    X_train, X_test, y_train, y_test = train_test_split(
+        iris.data, iris.target, test_size=0.2, random_state=42
+    )
+
+    clf = make_pipeline(StandardScaler(), LogisticRegression(max_iter=200))
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    print(f"Test accuracy: {acc:.2%}")
+
+
+if __name__ == "__main__":
+    train_sklearn_model()

--- a/examples/tensorflow_example.py
+++ b/examples/tensorflow_example.py
@@ -1,0 +1,27 @@
+import tensorflow as tf
+
+
+def train_tensorflow_model(num_samples: int = 1000, input_dim: int = 10,
+                           num_classes: int = 3, epochs: int = 20):
+    """Train a simple neural network using TensorFlow/Keras."""
+    X = tf.random.normal((num_samples, input_dim))
+    y = tf.random.uniform((num_samples,), maxval=num_classes, dtype=tf.int32)
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(32, activation='relu'),
+        tf.keras.layers.Dense(num_classes)
+    ])
+
+    model.compile(
+        optimizer='adam',
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=['accuracy']
+    )
+
+    model.fit(X, y, epochs=epochs, verbose=0)
+    loss, acc = model.evaluate(X, y, verbose=0)
+    print(f"Training accuracy: {acc:.2%}")
+
+
+if __name__ == "__main__":
+    train_tensorflow_model()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+pythonpath = .
 addopts = -ra


### PR DESCRIPTION
## Summary
- add minimal neural network demonstration with NumPy
- show small examples for PyTorch, TensorFlow, scikit-learn, and Hugging Face
- document example scripts in README
- configure pytest to include repo on PYTHONPATH

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687c56b7877c832981185c732477082b